### PR TITLE
ensure driver is in desired context to check for stale elements

### DIFF
--- a/lib/watir-webdriver/browser.rb
+++ b/lib/watir-webdriver/browser.rb
@@ -387,6 +387,7 @@ module Watir
         true
       end
     end
+    alias_method :assert_not_stale, :assert_exists
 
     def reset!
       # no-op

--- a/lib/watir-webdriver/elements/iframe.rb
+++ b/lib/watir-webdriver/elements/iframe.rb
@@ -9,23 +9,16 @@ module Watir
       element = locator.locate
       element or raise UnknownFrameException, "unable to locate #{@selector[:tag_name]} using #{selector_string}"
 
-      @parent.reset!
-
       FramedDriver.new(element, driver)
+    end
+
+    def switch_to!
+      locate.send :switch!
     end
 
     def assert_exists
       if @selector.has_key? :element
         raise UnknownFrameException, "wrapping a WebDriver element as a Frame is not currently supported"
-      end
-
-      if @element && !Watir.always_locate?
-        begin
-          @element.tag_name # rpc
-          return @element
-        rescue Selenium::WebDriver::Error::StaleElementReferenceError
-          @element = nil # re-locate
-        end
       end
 
       super
@@ -122,7 +115,7 @@ module Watir
     end
 
     def ==(other)
-      @element == other.wd
+      wd == other.wd
     end
     alias_method :eql?, :==
 


### PR DESCRIPTION
If the driver context is inside a frame, it will fail on an assert_not_stale call, even if the element is actually there. Specs for this are here - https://github.com/watir/watirspec/pull/50