### PR TITLE
Improve stale element handling

### DIFF
--- a/lib/watir-webdriver/attribute_helper.rb
+++ b/lib/watir-webdriver/attribute_helper.rb
@@ -68,30 +68,26 @@ module Watir
 
     def define_string_attribute(mname, aname)
       define_method mname do
-        assert_exists
-        @element.attribute(aname).to_s
+        attribute_value(aname).to_s
       end
     end
 
     def define_boolean_attribute(mname, aname)
       define_method mname do
-        assert_exists
-        @element.attribute(aname) == "true"
+        attribute_value(aname) == "true"
       end
     end
 
     def define_int_attribute(mname, aname)
       define_method mname do
-        assert_exists
-        value = @element.attribute(aname)
+        value = attribute_value(aname)
         value && Integer(value)
       end
     end
 
     def define_float_attribute(mname, aname)
       define_method mname do
-        assert_exists
-        value = @element.attribute(aname)
+        value = attribute_value(aname)
         value && Float(value)
       end
     end

--- a/lib/watir-webdriver/elements/button.rb
+++ b/lib/watir-webdriver/elements/button.rb
@@ -23,15 +23,13 @@ module Watir
     #
 
     def text
-      assert_exists
-
-      tn = @element.tag_name.downcase
+      tn = tag_name
 
       case tn
       when 'input'
-        @element.attribute(:value)
+        value
       when 'button'
-        @element.text
+        super
       else
         raise Exception::Error, "unknown tag name for button: #{tn}"
       end

--- a/lib/watir-webdriver/elements/checkbox.rb
+++ b/lib/watir-webdriver/elements/checkbox.rb
@@ -17,14 +17,7 @@ module Watir
     #
 
     def set(bool = true)
-      assert_exists
-      assert_enabled
-
-      if @element.selected?
-        @element.click unless bool
-      else
-        @element.click if bool
-      end
+      set? == bool ? assert_enabled : click
     end
 
     #
@@ -34,13 +27,11 @@ module Watir
 
     def set?
       assert_exists
-      @element.selected?
+      element_call { @element.selected? }
     end
 
     #
     # Unsets checkbox.
-    #
-    # Same as +set(false)+
     #
 
     def clear

--- a/lib/watir-webdriver/elements/file_field.rb
+++ b/lib/watir-webdriver/elements/file_field.rb
@@ -21,9 +21,8 @@ module Watir
     #
 
     def value=(path)
-      assert_exists
-      path = path.gsub(File::SEPARATOR, File::ALT_SEPARATOR) if File::ALT_SEPARATOR
-      @element.send_keys path
+      path.gsub!(File::SEPARATOR, File::ALT_SEPARATOR) if File::ALT_SEPARATOR
+      send_keys path
     end
 
   end # FileField

--- a/lib/watir-webdriver/elements/form.rb
+++ b/lib/watir-webdriver/elements/form.rb
@@ -10,7 +10,7 @@ module Watir
 
     def submit
       assert_exists
-      @element.submit
+      element_call { @element.submit }
       run_checkers
     end
 

--- a/lib/watir-webdriver/elements/iframe.rb
+++ b/lib/watir-webdriver/elements/iframe.rb
@@ -36,7 +36,7 @@ module Watir
 
       # this will actually give us the innerHTML instead of the outerHTML of the <frame>,
       # but given the choice this seems more useful
-      execute_atom(:getOuterHtml, @element.find_element(:tag_name => "html")).strip
+      element_call { execute_atom(:getOuterHtml, @element.find_element(:tag_name => "html")).strip }
     end
 
     def execute_script(*args)

--- a/lib/watir-webdriver/elements/option.rb
+++ b/lib/watir-webdriver/elements/option.rb
@@ -14,10 +14,7 @@ module Watir
     #   browser.select(:id => "foo").options.first.select
     #
 
-    def select
-      assert_exists
-      @element.click
-    end
+    alias_method :select, :click
 
     #
     # Toggles the selected state of this option.
@@ -26,10 +23,7 @@ module Watir
     #   browser.select(:id => "foo").options.first.toggle
     #
 
-    def toggle
-      assert_exists
-      @element.click
-    end
+    alias_method :toggle, :click
 
     #
     # Clears (i.e. toggles selected state) option.
@@ -39,7 +33,7 @@ module Watir
     #
 
     def clear
-      @element.click if selected?
+      click if selected?
     end
 
     #
@@ -50,7 +44,7 @@ module Watir
 
     def selected?
       assert_exists
-      @element.selected?
+      element_call { @element.selected? }
     end
 
     #
@@ -65,17 +59,15 @@ module Watir
     #
 
     def text
-      assert_exists
-
       # A little unintuitive - we'll return the 'label' or 'text' attribute if
       # they exist, otherwise the inner text of the element
 
       attribute = [:label, :text].find { |a| attribute? a }
 
       if attribute
-        @element.attribute(attribute)
+        attribute_value(attribute)
       else
-        @element.text
+        super
       end
     end
 

--- a/lib/watir-webdriver/elements/radio.rb
+++ b/lib/watir-webdriver/elements/radio.rb
@@ -7,10 +7,7 @@ module Watir
     #
 
     def set
-      assert_exists
-      assert_enabled
-
-      @element.click unless set?
+      click unless set?
     end
 
     #
@@ -21,7 +18,7 @@ module Watir
 
     def set?
       assert_exists
-      @element.selected?
+      element_call { @element.selected? }
     end
 
   end # Radio

--- a/lib/watir-webdriver/elements/select.rb
+++ b/lib/watir-webdriver/elements/select.rb
@@ -46,7 +46,6 @@ module Watir
     #
 
     def include?(str_or_rx)
-      assert_exists
       # TODO: optimize similar to selected?
       options.any? { |e| str_or_rx === e.text }
     end
@@ -88,7 +87,11 @@ module Watir
 
     def selected?(str_or_rx)
       assert_exists
-      matches = @element.find_elements(:tag_name, 'option').select { |e| str_or_rx === e.text || str_or_rx === e.attribute(:label) }
+      matches = element_call do
+        @element.find_elements(:tag_name, 'option').select do |e|
+          str_or_rx === e.text || str_or_rx === e.attribute(:label)
+        end
+      end
 
       if matches.empty?
         raise UnknownObjectException, "Unable to locate option matching #{str_or_rx.inspect}"
@@ -117,7 +120,6 @@ module Watir
     #
 
     def selected_options
-      assert_exists
       options.select { |e| e.selected? }
     end
 
@@ -140,14 +142,18 @@ module Watir
       xpath = option_xpath_for(how, string)
 
       if multiple?
-        elements = @element.find_elements(:xpath, xpath)
+        elements = element_call do
+          @element.find_elements(:xpath, xpath)
+        end
         no_value_found(string) if elements.empty?
 
         elements.each { |e| e.click unless e.selected? }
         elements.first.text
       else
         begin
-          e = @element.find_element(:xpath, xpath)
+          e = element_call do
+            @element.find_element(:xpath, xpath)
+          end
         rescue Selenium::WebDriver::Error::NoSuchElementError
           no_value_found(string)
         end
@@ -159,7 +165,9 @@ module Watir
     end
 
     def select_by_regexp(how, exp)
-      elements = @element.find_elements(:tag_name, 'option')
+      elements = element_call do
+        @element.find_elements(:tag_name, 'option')
+      end
       no_value_found(nil, "no options in select list") if elements.empty?
 
       if multiple?

--- a/lib/watir-webdriver/user_editable.rb
+++ b/lib/watir-webdriver/user_editable.rb
@@ -23,10 +23,7 @@ module Watir
     #
 
     def append(*args)
-      assert_exists
-      assert_writable
-
-      @element.send_keys(*args)
+      send_keys(*args)
     end
     alias_method :<<, :append
 

--- a/spec/always_locate_spec.rb
+++ b/spec/always_locate_spec.rb
@@ -1,0 +1,50 @@
+require File.expand_path('watirspec/spec_helper', File.dirname(__FILE__))
+
+describe 'Watir' do
+  describe '#always_locate?' do
+
+    before do
+      browser.goto WatirSpec.url_for('removed_element.html', :needs_server => true)
+    end
+
+    it 'handles #exists? when the element is stale' do
+      element = browser.div(:id => "text")
+      expect(element.exists?).to be true
+
+      browser.refresh
+
+      if Watir.always_locate?
+        expect(element.exists?).to be true
+      else
+        expect(element.exists?).to be false
+      end
+    end
+
+    it 'handles #exists? when the element is not stale' do
+      element = browser.div(:id => "text")
+      expect(element.exists?).to be true
+
+      # exception raised if element is re-looked up
+      allow(browser.driver).to receive(:find_element).with(:id, 'text') { raise }
+
+      if Watir.always_locate?
+        expect { element.exists? }.to raise_error
+      else
+        expect { element.exists? }.to_not raise_error
+      end
+    end
+
+    it 'handles exceptions when taking an action on a stale element' do
+      element = browser.div(:id => "text")
+      expect(element.exists?).to be true
+
+      browser.refresh
+
+      if Watir.always_locate?
+        expect { element.text }.to_not raise_error
+      else
+        expect { element.text }.to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
Element#assert_not_stale as currently implemented is useful for more static interactions with the page (refreshes and the like)
With more dynamic updates to the DOM, we sometimes have elements going stale between the #assert_not_stale call and the wire call that uses the element object.

These updates: 
1) Reduce the number of places where wire calls are made directly and push the implementation to the Element superclass where possible. 
2) Re-look up the element if it is stale, but still exists. If it passes the #assert_not_stale, then becomes stale, there is no reason to not retry instead of letting the test fail.