### PR TITLE
update error names

### DIFF
--- a/lib/watir-webdriver/elements/element.rb
+++ b/lib/watir-webdriver/elements/element.rb
@@ -414,7 +414,7 @@ module Watir
 
     def present?
       exists? && visible?
-    rescue Selenium::WebDriver::Error::ObsoleteElementError, UnknownObjectException
+    rescue Selenium::WebDriver::Error::StaleElementReferenceError, UnknownObjectException
       # if the element disappears between the exists? and visible? calls,
       # consider it not present.
       false

--- a/lib/watir-webdriver/elements/iframe.rb
+++ b/lib/watir-webdriver/elements/iframe.rb
@@ -23,7 +23,7 @@ module Watir
         begin
           @element.tag_name # rpc
           return @element
-        rescue Selenium::WebDriver::Error::ObsoleteElementError
+        rescue Selenium::WebDriver::Error::StaleElementReferenceError
           @element = nil # re-locate
         end
       end

--- a/lib/watir-webdriver/elements/select.rb
+++ b/lib/watir-webdriver/elements/select.rb
@@ -208,7 +208,7 @@ module Watir
 
     def safe_text(element)
       element.text
-    rescue Selenium::WebDriver::Error::ObsoleteElementError, Selenium::WebDriver::Error::UnhandledAlertError
+    rescue Selenium::WebDriver::Error::StaleElementReferenceError, Selenium::WebDriver::Error::UnhandledAlertError
       # guard for scenario where selecting the element changes the page, making our element obsolete
 
       ''

--- a/lib/watir-webdriver/locators/element_locator.rb
+++ b/lib/watir-webdriver/locators/element_locator.rb
@@ -39,7 +39,7 @@ module Watir
       # It is also used to alter behavior of methods locating more than one type of element
       # (e.g. text_field locates both input and textarea)
       validate_element(element) if element
-    rescue Selenium::WebDriver::Error::NoSuchElementError, Selenium::WebDriver::Error::ObsoleteElementError
+    rescue Selenium::WebDriver::Error::NoSuchElementError, Selenium::WebDriver::Error::StaleElementReferenceError
       nil
     end
 

--- a/lib/watir-webdriver/wait.rb
+++ b/lib/watir-webdriver/wait.rb
@@ -190,7 +190,7 @@ module Watir
       timeout ||= Watir.default_timeout
       message = "waiting for #{selector_string} to disappear"
       Watir::Wait.while(timeout, message) { present? }
-    rescue Selenium::WebDriver::Error::ObsoleteElementError
+    rescue Selenium::WebDriver::Error::StaleElementReferenceError
       # it's not present
     end
 

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -35,7 +35,7 @@ describe Watir::Element do
       browser.goto WatirSpec.url_for('removed_element.html', :needs_server => true)
     end
 
-    it "should not propagate ObsoleteElementErrors" do
+    it "should not propagate StaleElementReferenceErrors" do
       button  = browser.button(:id => "remove-button")
       element = browser.div(:id => "text")
 


### PR DESCRIPTION
Update references to ObsoleteElementError exception with the [new name] (https://github.com/SeleniumHQ/selenium/blob/master/rb/lib/selenium/webdriver/common/error.rb#L191) - StaleElementReferenceError for consistency