### PR TITLE
Only re-look up elements when they aren't stale

### DIFF
--- a/lib/watir-webdriver/elements/element.rb
+++ b/lib/watir-webdriver/elements/element.rb
@@ -495,16 +495,16 @@ module Watir
   protected
 
     def assert_exists
-      reset! if Watir.always_locate?
+      begin
+        assert_not_stale if @element ||= @selector[:element]
+      rescue UnknownObjectException => ex
+        raise ex if @selector[:element] || !Watir.always_locate?
+      end
 
-      if @element ||= @selector[:element]
-        assert_not_stale
-      else
-        @element = locate
+      @element ||= locate
 
-        unless @element
-          raise UnknownObjectException, "unable to locate element, using #{selector_string}"
-        end
+      unless @element
+        raise UnknownObjectException, "unable to locate element, using #{selector_string}"
       end
     end
 

--- a/spec/always_locate_spec.rb
+++ b/spec/always_locate_spec.rb
@@ -7,34 +7,26 @@ describe 'Watir' do
       browser.goto WatirSpec.url_for('removed_element.html', :needs_server => true)
     end
 
-    it 'handles #exists? when the element is stale' do
+    it 'determines whether #exist? returns false for stale element' do
       element = browser.div(:id => "text")
       expect(element.exists?).to be true
 
       browser.refresh
 
-      if Watir.always_locate?
-        expect(element.exists?).to be true
-      else
-        expect(element.exists?).to be false
-      end
+      expect(element.exists?).to be Watir.always_locate?
     end
 
-    it 'handles #exists? when the element is not stale' do
+    it 'allows using cached elements regardless of setting, when element is not stale' do
       element = browser.div(:id => "text")
       expect(element.exists?).to be true
 
       # exception raised if element is re-looked up
       allow(browser.driver).to receive(:find_element).with(:id, 'text') { raise }
 
-      if Watir.always_locate?
-        expect { element.exists? }.to raise_error
-      else
-        expect { element.exists? }.to_not raise_error
-      end
+      expect { element.exists? }.to_not raise_error
     end
 
-    it 'handles exceptions when taking an action on a stale element' do
+    it 'determines whether an exception is raised when taking an action on a stale element' do
       element = browser.div(:id => "text")
       expect(element.exists?).to be true
 


### PR DESCRIPTION
This essentially changes always_locate to locate_when_necessary

The Watir.always_locate? setting currently conflates whether to cache and whether to fail when stale. [Reading through](http://watirmelon.com/2011/08/02/watir-webdriver-obselete-element-error/) the [background conversations](https://groups.google.com/forum/#!topic/watir-general/WhwpPvzHWmM/discussion) for implementing always_locate, it seems the important issue is that it not throw an exception when the element goes stale. With my test suite I saw a performance improvement of 15-20%. So, huge performance bump without affecting the desired behavior.