### PR TITLE
addresses race conditions with slow loading frames

### DIFF
--- a/lib/watir-webdriver/elements/iframe.rb
+++ b/lib/watir-webdriver/elements/iframe.rb
@@ -48,6 +48,7 @@ module Watir
   class IFrameCollection < ElementCollection
 
     def to_a
+      element_indexes = elements.map { |el| all_elements.index(el) }
       element_indexes.map { |idx| element_class.new(@parent, tag_name: @selector[:tag_name], :index => idx ) }
     end
 
@@ -57,14 +58,12 @@ module Watir
 
     private
 
-    def element_indexes
-      all_elements = locator_class.new(
+    def all_elements
+      locator_class.new(
           @parent.wd,
-          {tag_name: @selector[:tag_name]},
+          { tag_name: @selector[:tag_name] },
           element_class.attribute_list
       ).locate_all
-
-      elements.map { |el| all_elements.index(el) }
     end
 
   end # IFrameCollection


### PR DESCRIPTION
For #299 we supported selectors for frames by doing a lookup of all the frame elements and all the frame elements matching the provided selector. I'm hitting a race condition where the frame hasn't finished loading on the page. With the current code the all_elements variable returns a size of zero, but the ElementCollection#elements call returns with a size of one.  

The subset of matching iframes should never be greater than all the iframes on the page.