### PR TITLE
Use full path to exceptions in specs

### DIFF
--- a/lib/watir-webdriver/exception.rb
+++ b/lib/watir-webdriver/exception.rb
@@ -12,8 +12,6 @@ module Watir
     class MissingWayOfFindingObjectException < Error; end
     class UnknownCellException < Error; end
     class NoMatchingWindowFoundException < Error; end
-    class NoStatusBarException < Error; end
-    class NavigationException < Error; end
     class UnknownFrameException < Error; end
     class UnknownRowException < Error; end
 

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -70,7 +70,7 @@ describe Watir::Browser do
     b.goto WatirSpec.url_for "definition_lists.html"
     b.close
 
-    expect { b.dl(:id => "experience-list").id }.to raise_error(Error, "browser was closed")
+    expect { b.dl(:id => "experience-list").id }.to raise_error(Watir::Exception::Error, "browser was closed")
   end
 
   describe "#wait_while" do

--- a/spec/element_locator_spec.rb
+++ b/spec/element_locator_spec.rb
@@ -368,7 +368,7 @@ describe Watir::ElementLocator do
         valid_attributes = Watir::Input.attributes
 
         expect { locate_one(bad_selector, valid_attributes) }.to \
-        raise_error(MissingWayOfFindingObjectException, "invalid attribute: :href")
+        raise_error(Watir::Exception::MissingWayOfFindingObjectException, "invalid attribute: :href")
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,6 @@ require 'rubygems'
 require 'rspec'
 
 include Watir
-include Watir::Exception
 
 if ENV['ALWAYS_LOCATE'] == "false"
   Watir.always_locate = false


### PR DESCRIPTION
Also cleans up unused exceptions.

Related to watir/watirspec#61