### PR TITLE
Ensure not stale

### DIFF
--- a/lib/watir-webdriver/browser.rb
+++ b/lib/watir-webdriver/browser.rb
@@ -387,7 +387,7 @@ module Watir
         true
       end
     end
-    alias_method :assert_not_stale, :assert_exists
+    alias_method :ensure_not_stale, :assert_exists
 
     def reset!
       # no-op

--- a/lib/watir-webdriver/elements/element.rb
+++ b/lib/watir-webdriver/elements/element.rb
@@ -44,6 +44,7 @@ module Watir
       assert_exists
       true
     rescue UnknownObjectException, UnknownFrameException
+      reset!
       false
     end
     alias_method :exist?, :exists?
@@ -511,9 +512,7 @@ module Watir
     def ensure_not_stale
       @parent.ensure_not_stale
       @parent.switch_to! if @parent.is_a? IFrame
-      begin
-        @element.enabled? # do a staleness check - any wire call will do.
-      rescue Selenium::WebDriver::Error::ObsoleteElementError => ex
+      if stale?
         if Watir.always_locate? && ! @selector[:element]
           @element = locate
         else
@@ -523,6 +522,13 @@ module Watir
       assert_element_found
     end
 
+    def stale?
+      @element.enabled? # any wire call will check for staleness
+      false
+    rescue Selenium::WebDriver::Error::ObsoleteElementError
+      true
+    end
+
     def assert_element_found
       unless @element
         raise UnknownObjectException, "unable to locate element, using #{selector_string}"
@@ -530,6 +536,7 @@ module Watir
     end
 
     def reset!
+      @parent.reset!
       @element = nil
     end
 

--- a/lib/watir-webdriver/elements/element.rb
+++ b/lib/watir-webdriver/elements/element.rb
@@ -496,21 +496,23 @@ module Watir
 
     # Ensure that the element exists, making sure that it is not stale and located if necessary
     def assert_exists
-       @element ||= @selector[:element]
+      @element ||= @selector[:element]
 
-       if @element
-         ensure_not_stale # ensure not stale
-       else
-         @element = locate
-       end
+      if @element
+        ensure_not_stale # ensure not stale
+      else
+        @element = locate
+      end
 
-       assert_element_found
+      assert_element_found
     end
 
     # Ensure that the element isn't stale, by relocating if it is (unless always_locate = false)
     def ensure_not_stale
       # Performance shortcut; only need recursive call to ensure context if stale in current context
-      ensure_context if stale?
+      return unless stale?
+
+      ensure_context
       if stale?
         if Watir.always_locate? && !@selector[:element]
           @element = locate
@@ -553,7 +555,7 @@ module Watir
       @selector.inspect
     end
 
-    # This makes sure we switch to desired browser context (frame)
+    # Ensure the driver is in the desired browser context
     def ensure_context
       @parent.is_a?(IFrame) ? @parent.switch_to! : @parent.assert_exists
     end

--- a/lib/watir-webdriver/elements/element.rb
+++ b/lib/watir-webdriver/elements/element.rb
@@ -44,7 +44,6 @@ module Watir
       assert_exists
       true
     rescue UnknownObjectException, UnknownFrameException
-      reset!
       false
     end
     alias_method :exist?, :exists?
@@ -536,7 +535,6 @@ module Watir
     end
 
     def reset!
-      @parent.reset!
       @element = nil
     end
 
@@ -597,7 +595,6 @@ module Watir
       yield
     rescue Selenium::WebDriver::Error::StaleElementReferenceError
       raise unless Watir.always_locate?
-      reset!
       assert_exists
       retry
     end

--- a/lib/watir-webdriver/elements/element.rb
+++ b/lib/watir-webdriver/elements/element.rb
@@ -510,7 +510,7 @@ module Watir
 
     # Ensure that the element isn't stale, by relocating if it is (unless always_locate = false)
     def ensure_not_stale
-      @parent.ensure_not_stale
+      @parent.assert_exists
       @parent.switch_to! if @parent.is_a? IFrame
       if stale?
         if Watir.always_locate? && ! @selector[:element]

--- a/lib/watir-webdriver/elements/element.rb
+++ b/lib/watir-webdriver/elements/element.rb
@@ -510,10 +510,10 @@ module Watir
 
     # Ensure that the element isn't stale, by relocating if it is (unless always_locate = false)
     def ensure_not_stale
-      @parent.assert_exists
-      @parent.switch_to! if @parent.is_a? IFrame
+      # Performance shortcut; only need recursive call to ensure context if stale in current context
+      ensure_context if stale?
       if stale?
-        if Watir.always_locate? && ! @selector[:element]
+        if Watir.always_locate? && !@selector[:element]
           @element = locate
         else
           reset!
@@ -541,7 +541,7 @@ module Watir
     end
 
     def locate
-      @parent.is_a?(IFrame) ? @parent.switch_to! : @parent.assert_exists
+      ensure_context
       locator_class.new(@parent.wd, @selector, self.class.attribute_list).locate
     end
 
@@ -553,6 +553,11 @@ module Watir
 
     def selector_string
       @selector.inspect
+    end
+
+    # This makes sure we switch to desired browser context (frame)
+    def ensure_context
+      @parent.is_a?(IFrame) ? @parent.switch_to! : @parent.assert_exists
     end
 
     def attribute?(attribute)

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -75,6 +75,20 @@ describe Watir::Element do
 
       expect(browser.div(:id, 'text')).to_not exist
     end
+
+    it "returns appropriate value when an ancestor element becomes stale" do
+      stale_element = browser.div(id: 'top').div(id: 'middle').div(id: 'bottom')
+      expect(stale_element.present?).to be true # look up and store @element for each element in hierarchy
+
+      grandparent = stale_element.instance_variable_get('@parent').instance_variable_get('@parent').instance_variable_get('@element')
+
+      # simulate element going stale during lookup
+      allow(grandparent).to receive('enabled?') { raise Selenium::WebDriver::Error::ObsoleteElementError }
+
+      browser.refresh
+      expect(stale_element.present?).to be Watir.always_locate?
+      expect(stale_element.present?).to be true
+    end
   end
 
   describe "#element_call" do

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -87,7 +87,6 @@ describe Watir::Element do
 
       browser.refresh
       expect(stale_element.present?).to be Watir.always_locate?
-      expect(stale_element.present?).to be true
     end
   end
 

--- a/spec/html/removed_element.html
+++ b/spec/html/removed_element.html
@@ -13,5 +13,12 @@
   <body>
     <button id='remove-button' onclick="removeText()">Remove text</button>
     <div id="text">Text</div>
+
+    <div id='top'>Top Element>
+      <div id='middle'>Middle Element>
+        <div id='bottom'>Bottom Element</div>
+      </div>
+    </div>
+
   </body>
 </html>


### PR DESCRIPTION
#286 fixed the issue with #211, but introduced a bug with a race condition for stale elements with multiple hierarchy elements. When the elements go stale, the current code does not re-lookup the top level element when Watir.always_locate? == true, and does not reset the entire chain of elements (only the top element) when Watir.always_locate? == false. This fixes the submitted specs and @bret made my previous implementation more readable and made the previous assert_not_stale better parallel the behavior or assert_exist.