### PR TITLE
Fix issue with rest-client update with running watir-spec

### DIFF
--- a/watir-webdriver.gemspec
+++ b/watir-webdriver.gemspec
@@ -32,5 +32,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "activesupport", "~> 3.0" # for pluralization during code generation
   s.add_development_dependency "pry"
   s.add_development_dependency "coveralls"
+  s.add_development_dependency "rest-client", "~> 1.7.3"
   s.add_development_dependency "yard-doctest"
 end


### PR DESCRIPTION
Looks like a new update to this gem might be breaking our tests. Doing a PR to verify, will un-comment this line as the fix if this PR fails on Travis.