### PR TITLE
Optimize regexp selectors when using xpath

### DIFF
--- a/lib/watir-webdriver/locators/button_locator.rb
+++ b/lib/watir-webdriver/locators/button_locator.rb
@@ -67,6 +67,11 @@ module Watir
       end
     end
 
+    def can_convert_regexp_to_contains?
+      # regexp conversion won't work with the complex xpath selector
+      false
+    end
+
     def tag_name_matches?(tag_name, _)
       !!(/^(input|button)$/ === tag_name)
     end

--- a/lib/watir-webdriver/locators/text_area_locator.rb
+++ b/lib/watir-webdriver/locators/text_area_locator.rb
@@ -3,6 +3,10 @@ module Watir
 
     private
 
+    def can_convert_regexp_to_contains?
+      false
+    end
+
     def normalize_selector(how, what)
       # We need to iterate through located elements and fetch
       # attribute value using WebDriver because XPath doesn't understand


### PR DESCRIPTION
Regexp selectors are highly inefficient as they require additional round
trip requests (to retrieve attribute values) for each element that
matches the simplified selector. This optimization limits the number of
requests needed by converting leading and trailing runs of literals in
each regular expression to to an xpath `contains` predicate. Note that
problematic regular expressions such as case insensitive patterns and
those containing '|' are not converted.