### PR TITLE
fix bug for multiple element matching same text

### DIFF
--- a/lib/watir-webdriver/locators/element_locator.rb
+++ b/lib/watir-webdriver/locators/element_locator.rb
@@ -397,7 +397,7 @@ module Watir
         "contains(concat(' ', @class, ' '), #{klass})"
       elsif key == :label && should_use_label_element?
         # we assume :label means a corresponding label element, not the attribute
-        text = "normalize-space()=#{XpathSupport.escape value}"
+        text = "normalize-space(text())=#{XpathSupport.escape value}"
         "(@id=//label[#{text}]/@for or parent::label[#{text}])"
       else
         "#{lhs_for(key)}=#{XpathSupport.escape value}"
@@ -407,7 +407,7 @@ module Watir
     def lhs_for(key)
       case key
       when :text, 'text'
-        'normalize-space()'
+        'normalize-space(text())'
       when :href
         # TODO: change this behaviour?
         'normalize-space(@href)'

--- a/spec/element_locator_spec.rb
+++ b/spec/element_locator_spec.rb
@@ -72,13 +72,13 @@ describe Watir::ElementLocator do
 
     describe "with special cased selectors" do
       it "normalizes space for :text" do
-        expect_one :xpath, ".//div[normalize-space()='foo']"
+        expect_one :xpath, ".//div[normalize-space(text())='foo']"
         locate_one tag_name: "div",
                    text: "foo"
       end
 
       it "translates :caption to :text" do
-        expect_one :xpath, ".//div[normalize-space()='foo']"
+        expect_one :xpath, ".//div[normalize-space(text())='foo']"
 
         locate_one tag_name: "div",
                    caption: "foo"
@@ -146,7 +146,7 @@ describe Watir::ElementLocator do
 
       it "uses the corresponding <label>'s @for attribute or parent::label when locating by label" do
         translated_type = "translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')"
-        expect_one :xpath, ".//input[#{translated_type}='text' and (@id=//label[normalize-space()='foo']/@for or parent::label[normalize-space()='foo'])]"
+        expect_one :xpath, ".//input[#{translated_type}='text' and (@id=//label[normalize-space(text())='foo']/@for or parent::label[normalize-space(text())='foo'])]"
 
         selector = [
           :tag_name, "input",


### PR DESCRIPTION
This is the behavior I expect for a text match. One instance of text == one element matched. It requires a few spec updates in: https://github.com/watir/watirspec/pull/65