### PR TITLE
Extract Checkers into separate API and run them after alert ok/close

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 ### Unreleased
 
-* Deprecated checkers. Use `Browser#after_hooks` instead.
+* New AfterHooks API that deprecates Checkers:
+  * Use `Browser#after_hooks#add` instead of `Browser#add_checker`
+  * Use `Browser#after_hooks#delete` instead of `Browser#disable_checker`
+  * Use `Browser#after_hooks#run` instead of `Browser#run_checkers`
+  * Use `Browser#after_hooks#without` instead of `Browser#without_checkers`
 
 ### 0.8.0 (2015-06-26)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+* Deprecated checkers. Use `Browser#after_hooks` instead.
+
 ### 0.8.0 (2015-06-26)
 
 * Ruby 1.8 is no longer supported. Ruby 1.9 still works, but not supported as well (#327)

--- a/lib/watir-webdriver.rb
+++ b/lib/watir-webdriver.rb
@@ -18,6 +18,7 @@ require 'watir-webdriver/locators/child_row_locator'
 require 'watir-webdriver/locators/child_cell_locator'
 require 'watir-webdriver/browser'
 require 'watir-webdriver/screenshot'
+require 'watir-webdriver/checkers'
 
 module Watir
   @always_locate = true

--- a/lib/watir-webdriver.rb
+++ b/lib/watir-webdriver.rb
@@ -18,7 +18,7 @@ require 'watir-webdriver/locators/child_row_locator'
 require 'watir-webdriver/locators/child_cell_locator'
 require 'watir-webdriver/browser'
 require 'watir-webdriver/screenshot'
-require 'watir-webdriver/checkers'
+require 'watir-webdriver/after_hooks'
 
 module Watir
   @always_locate = true

--- a/lib/watir-webdriver/after_hooks.rb
+++ b/lib/watir-webdriver/after_hooks.rb
@@ -1,7 +1,7 @@
 module Watir
 
   #
-  # Checkers are blocks that run after certain browser events.
+  # After hooks are blocks that run after certain browser events.
   # They are generally used to ensure application under test does not encounter
   # any error and are automatically executed after following events:
   #   1. Open URL.
@@ -10,34 +10,34 @@ module Watir
   #   4. Alert closing.
   #
 
-  class Checkers
+  class AfterHooks
     include Enumerable
 
     def initialize(browser)
       @browser = browser
-      @checkers = []
+      @after_hooks = []
     end
 
     #
-    # Adds new checker.
+    # Adds new after hook.
     #
     # @example
-    #   browser.checkers.add do |browser|
+    #   browser.after_hooks.add do |browser|
     #     browser.text.include?("Server Error") and puts "Application exception or 500 error!"
     #   end
     #   browser.goto "www.watir.com/404"
     #   "Application exception or 500 error!"
     #
-    # @param [#call] checker Object responding to call
-    # @yield Checker block
+    # @param [#call] after_hook Object responding to call
+    # @yield after_hook block
     # @yieldparam [Watir::Browser]
     #
 
-    def add(checker = nil, &block)
+    def add(after_hook = nil, &block)
       if block_given?
-        @checkers << block
-      elsif checker.respond_to? :call
-        @checkers << checker
+        @after_hooks << block
+      elsif after_hook.respond_to? :call
+        @after_hooks << after_hook
       else
         raise ArgumentError, "expected block or object responding to #call"
       end
@@ -45,88 +45,88 @@ module Watir
     alias_method :<<, :add
 
     #
-    # Deletes checker.
+    # Deletes after hook.
     #
     # @example
-    #   browser.checkers.add do |browser|
+    #   browser.after_hooks.add do |browser|
     #     browser.text.include?("Server Error") and puts "Application exception or 500 error!"
     #   end
     #   browser.goto "www.watir.com/404"
     #   "Application exception or 500 error!"
-    #   browser.checkers.delete browser.checkers[0]
+    #   browser.after_hooks.delete browser.after_hooks[0]
     #   browser.refresh
     #
 
-    def delete(checker)
-      @checkers.delete(checker)
+    def delete(after_hook)
+      @after_hooks.delete(after_hook)
     end
 
     #
-    # Runs checkers.
+    # Runs after hooks.
     #
 
     def run
-      if @checkers.any? && @browser.window.present?
-        each { |checker| checker.call(@browser) }
+      if @after_hooks.any? && @browser.window.present?
+        each { |after_hook| after_hook.call(@browser) }
       end
     end
 
     #
-    # Executes a block without running error checkers.
+    # Executes a block without running error after hooks.
     #
     # @example
-    #   browser.checkers.without do |browser|
+    #   browser.after_hooks.without do |browser|
     #     browser.element(name: "new_user_button").click
     #   end
     #
-    # @yield Block that is executed without checkers being run
+    # @yield Block that is executed without after hooks being run
     # @yieldparam [Watir::Browser]
     #
 
     def without
-      current_checkers = @checkers
-      @checkers = []
+      current_after_hooks = @after_hooks
+      @after_hooks = []
       yield(@browser)
     ensure
-      @checkers = current_checkers
+      @after_hooks = current_after_hooks
     end
 
     #
-    # Yields each checker.
+    # Yields each after hook.
     #
-    # @yieldparam [#call] checker Object responding to call
+    # @yieldparam [#call] after_hook Object responding to call
     #
 
     def each
-      @checkers.each { |checker| yield checker }
+      @after_hooks.each { |after_hook| yield after_hook }
     end
 
     #
-    # Returns number of checkers.
+    # Returns number of after hooks.
     #
     # @example
-    #   browser.checkers.add { puts 'Some checker.' }
-    #   browser.checkers.length
+    #   browser.after_hooks.add { puts 'Some after_hook.' }
+    #   browser.after_hooks.length
     #   #=> 1
     #
     # @return [Fixnum]
     #
 
     def length
-      @checkers.length
+      @after_hooks.length
     end
     alias_method :size, :length
 
     #
-    # Get the checker at the given index.
+    # Gets the after hook at the given index.
     #
     # @param [Fixnum] index
     # @return [#call]
     #
 
     def [](index)
-      @checkers[index]
+      @after_hooks[index]
     end
 
-  end # Checkers
+  end # AfterHooks
 end # Watir

--- a/lib/watir-webdriver/alert.rb
+++ b/lib/watir-webdriver/alert.rb
@@ -3,8 +3,8 @@ module Watir
 
     include EventuallyPresent
 
-    def initialize(target_locator)
-      @target_locator = target_locator
+    def initialize(browser)
+      @browser = browser
       @alert = nil
     end
 
@@ -35,6 +35,7 @@ module Watir
     def ok
       assert_exists
       @alert.accept
+      @browser.checkers.run
     end
 
     #
@@ -49,6 +50,7 @@ module Watir
     def close
       assert_exists
       @alert.dismiss
+      @browser.checkers.run
     end
 
     #
@@ -93,7 +95,7 @@ module Watir
     private
 
     def assert_exists
-      @alert = @target_locator.alert
+      @alert = @browser.driver.switch_to.alert
     rescue Selenium::WebDriver::Error::NoAlertPresentError
       raise Exception::UnknownObjectException, 'unable to locate alert'
     end

--- a/lib/watir-webdriver/alert.rb
+++ b/lib/watir-webdriver/alert.rb
@@ -35,7 +35,7 @@ module Watir
     def ok
       assert_exists
       @alert.accept
-      @browser.checkers.run
+      @browser.after_hooks.run
     end
 
     #
@@ -50,7 +50,7 @@ module Watir
     def close
       assert_exists
       @alert.dismiss
-      @browser.checkers.run
+      @browser.after_hooks.run
     end
 
     #

--- a/lib/watir-webdriver/browser.rb
+++ b/lib/watir-webdriver/browser.rb
@@ -291,12 +291,12 @@ module Watir
     end
 
     #
-    # @deprecated Use `Watir::Checkers#disable` instead
+    # @deprecated Use `Watir::Checkers#delete` instead
     #
 
     def disable_checker(checker)
-      warn 'Browser#disable_checker is deprecated. Use Browser#checkers#disable instead.'
-      @checkers.disable(checker)
+      warn 'Browser#disable_checker is deprecated. Use Browser#checkers#delete instead.'
+      @checkers.delete(checker)
     end
 
     #

--- a/lib/watir-webdriver/browser.rb
+++ b/lib/watir-webdriver/browser.rb
@@ -10,6 +10,7 @@ module Watir
     include Waitable
 
     attr_reader :driver
+    attr_reader :checkers
     alias_method :wd, :driver # ensures duck typing with Watir::Element
 
     class << self
@@ -49,9 +50,9 @@ module Watir
         raise ArgumentError, "expected Symbol or Selenium::WebDriver::Driver, got #{browser.class}"
       end
 
-      @error_checkers = []
+      @checkers = Checkers.new(self)
       @current_frame  = nil
-      @closed         = false
+      @closed = false
     end
 
     def inspect
@@ -74,7 +75,7 @@ module Watir
       uri = "http://#{uri}" unless uri =~ URI.regexp
 
       @driver.navigate.to uri
-      run_checkers
+      @checkers.run
 
       url
     end
@@ -199,7 +200,7 @@ module Watir
 
     def refresh
       @driver.navigate.refresh
-      run_checkers
+      @checkers.run
     end
 
     #
@@ -281,79 +282,39 @@ module Watir
     end
 
     #
-    # Adds new checker.
-    #
-    # Checkers are generally used to ensure application under test does not encounter
-    # any error. They are automatically executed after following events:
-    #   1. Open URL
-    #   2. Refresh page
-    #   3. Click, double-click or right-click on element
-    #
-    # @example
-    #   browser.add_checker do |page|
-    #     page.text.include?("Server Error") and puts "Application exception or 500 error!"
-    #   end
-    #   browser.goto "www.watir.com/404"
-    #   "Application exception or 500 error!"
-    #
-    # @param [#call] checker Object responding to call
-    # @yield Checker block
-    # @yieldparam [Watir::Browser]
+    # @deprecated Use `Watir::Checkers#add` instead
     #
 
     def add_checker(checker = nil, &block)
-      if block_given?
-        @error_checkers << block
-      elsif checker.respond_to? :call
-        @error_checkers << checker
-      else
-        raise ArgumentError, "expected block or object responding to #call"
-      end
+      warn 'Browser#add_checker is deprecated. Use Browser#checkers#add instead.'
+      @checkers.add(checker, &block)
     end
 
     #
-    # Deletes checker.
-    #
-    # @example
-    #   checker = lambda do |page|
-    #     page.text.include?("Server Error") and puts "Application exception or 500 error!"
-    #   end
-    #   browser.add_checker checker
-    #   browser.goto "www.watir.com/404"
-    #   "Application exception or 500 error!"
-    #   browser.disable_checker checker
-    #   browser.refresh
+    # @deprecated Use `Watir::Checkers#disable` instead
     #
 
     def disable_checker(checker)
-      @error_checkers.delete(checker)
+      warn 'Browser#disable_checker is deprecated. Use Browser#checkers#disable instead.'
+      @checkers.disable(checker)
     end
 
     #
-    # Runs checkers.
+    # @deprecated Use `Watir::Checkers#run` instead
     #
 
     def run_checkers
-      @error_checkers.each { |e| e.call(self) } if !@error_checkers.empty? && window.present?
+      warn 'Browser#run_checkers is deprecated. Use Browser#checkers#run instead.'
+      @checkers.run
     end
 
     #
-    # Executes a block without running error checkers.
-    #
-    # @example
-    #   browser.without_checkers do
-    #     browser.element(name: "new_user_button").click
-    #   end
-    #
-    # @yieldparam [Watir::Browser]
+    # @deprecated Use `Watir::Checkers#without` instead
     #
 
-    def without_checkers
-      current_checkers = @error_checkers
-      @error_checkers = []
-      yield(self)
-    ensure
-      @error_checkers = current_checkers
+    def without_checkers(&block)
+      warn 'Browser#without_checkers is deprecated. Use Browser#checkers#without instead.'
+      @checkers.without(&block)
     end
 
     #

--- a/lib/watir-webdriver/browser.rb
+++ b/lib/watir-webdriver/browser.rb
@@ -10,7 +10,7 @@ module Watir
     include Waitable
 
     attr_reader :driver
-    attr_reader :checkers
+    attr_reader :after_hooks
     alias_method :wd, :driver # ensures duck typing with Watir::Element
 
     class << self
@@ -50,7 +50,7 @@ module Watir
         raise ArgumentError, "expected Symbol or Selenium::WebDriver::Driver, got #{browser.class}"
       end
 
-      @checkers = Checkers.new(self)
+      @after_hooks = AfterHooks.new(self)
       @current_frame  = nil
       @closed = false
     end
@@ -75,7 +75,7 @@ module Watir
       uri = "http://#{uri}" unless uri =~ URI.regexp
 
       @driver.navigate.to uri
-      @checkers.run
+      @after_hooks.run
 
       url
     end
@@ -200,7 +200,7 @@ module Watir
 
     def refresh
       @driver.navigate.refresh
-      @checkers.run
+      @after_hooks.run
     end
 
     #
@@ -282,39 +282,39 @@ module Watir
     end
 
     #
-    # @deprecated Use `Watir::Checkers#add` instead
+    # @deprecated Use `Watir::AfterHooks#add` instead
     #
 
     def add_checker(checker = nil, &block)
-      warn 'Browser#add_checker is deprecated. Use Browser#checkers#add instead.'
-      @checkers.add(checker, &block)
+      warn 'Browser#add_checker is deprecated. Use Browser#after_hooks#add instead.'
+      @after_hooks.add(checker, &block)
     end
 
     #
-    # @deprecated Use `Watir::Checkers#delete` instead
+    # @deprecated Use `Watir::AfterHooks#delete` instead
     #
 
     def disable_checker(checker)
-      warn 'Browser#disable_checker is deprecated. Use Browser#checkers#delete instead.'
-      @checkers.delete(checker)
+      warn 'Browser#disable_checker is deprecated. Use Browser#after_hooks#delete instead.'
+      @after_hooks.delete(checker)
     end
 
     #
-    # @deprecated Use `Watir::Checkers#run` instead
+    # @deprecated Use `Watir::AfterHooks#run` instead
     #
 
     def run_checkers
-      warn 'Browser#run_checkers is deprecated. Use Browser#checkers#run instead.'
-      @checkers.run
+      warn 'Browser#run_checkers is deprecated. Use Browser#after_hooks#run instead.'
+      @after_hooks.run
     end
 
     #
-    # @deprecated Use `Watir::Checkers#without` instead
+    # @deprecated Use `Watir::AfterHooks#without` instead
     #
 
     def without_checkers(&block)
-      warn 'Browser#without_checkers is deprecated. Use Browser#checkers#without instead.'
-      @checkers.without(&block)
+      warn 'Browser#without_checkers is deprecated. Use Browser#after_hooks#without instead.'
+      @after_hooks.without(&block)
     end
 
     #

--- a/lib/watir-webdriver/browser.rb
+++ b/lib/watir-webdriver/browser.rb
@@ -191,7 +191,7 @@ module Watir
     #
 
     def alert
-      Alert.new driver.switch_to
+      Alert.new(self)
     end
 
     #

--- a/lib/watir-webdriver/checkers.rb
+++ b/lib/watir-webdriver/checkers.rb
@@ -1,0 +1,88 @@
+module Watir
+  class Checkers
+
+    def initialize(browser)
+      @browser = browser
+      @error_checkers = []
+    end
+
+    #
+    # Adds new checker.
+    #
+    # Checkers are generally used to ensure application under test does not encounter
+    # any error. They are automatically executed after following events:
+    #   1. Open URL.
+    #   2. Refresh page.
+    #   3. Click, double-click or right-click on element.
+    #
+    # @example
+    #   browser.checkers.add do |page|
+    #     page.text.include?("Server Error") and puts "Application exception or 500 error!"
+    #   end
+    #   browser.goto "www.watir.com/404"
+    #   "Application exception or 500 error!"
+    #
+    # @param [#call] checker Object responding to call
+    # @yield Checker block
+    # @yieldparam [Watir::Browser]
+    #
+
+    def add(checker = nil, &block)
+      if block_given?
+        @error_checkers << block
+      elsif checker.respond_to? :call
+        @error_checkers << checker
+      else
+        raise ArgumentError, "expected block or object responding to #call"
+      end
+    end
+
+    #
+    # Deletes checker.
+    #
+    # @example
+    #   checker = lambda do |page|
+    #     page.text.include?("Server Error") and puts "Application exception or 500 error!"
+    #   end
+    #   browser.checkers.add checker
+    #   browser.goto "www.watir.com/404"
+    #   "Application exception or 500 error!"
+    #   browser.disable_checker checker
+    #   browser.refresh
+    #
+
+    def disable(checker)
+      @error_checkers.delete(checker)
+    end
+
+    #
+    # Runs checkers.
+    #
+
+    def run
+      if @error_checkers.any? && @browser.window.present?
+        @error_checkers.each { |e| e.call(@browser) }
+      end
+    end
+
+    #
+    # Executes a block without running error checkers.
+    #
+    # @example
+    #   browser.checkers.without do
+    #     browser.element(name: "new_user_button").click
+    #   end
+    #
+    # @yieldparam [Watir::Browser]
+    #
+
+    def without
+      current_checkers = @error_checkers
+      @error_checkers = []
+      yield(@browser)
+    ensure
+      @error_checkers = current_checkers
+    end
+
+  end # Checkers
+end # Watir

--- a/lib/watir-webdriver/elements/element.rb
+++ b/lib/watir-webdriver/elements/element.rb
@@ -129,7 +129,7 @@ module Watir
         end
       end
 
-      run_checkers
+      browser.checkers.run
     end
 
     #
@@ -145,7 +145,7 @@ module Watir
       assert_has_input_devices_for :double_click
 
       element_call { driver.action.double_click(@element).perform }
-      run_checkers
+      browser.checkers.run
     end
 
     #
@@ -161,7 +161,7 @@ module Watir
       assert_has_input_devices_for :right_click
 
       element_call { driver.action.context_click(@element).perform }
-      run_checkers
+      browser.checkers.run
     end
 
     #
@@ -436,14 +436,6 @@ module Watir
       else
         attribute_value("style").to_s.strip
       end
-    end
-
-    #
-    # Runs checkers.
-    #
-
-    def run_checkers
-      @parent.run_checkers
     end
 
     #

--- a/lib/watir-webdriver/elements/element.rb
+++ b/lib/watir-webdriver/elements/element.rb
@@ -129,7 +129,7 @@ module Watir
         end
       end
 
-      browser.checkers.run
+      browser.after_hooks.run
     end
 
     #
@@ -145,7 +145,7 @@ module Watir
       assert_has_input_devices_for :double_click
 
       element_call { driver.action.double_click(@element).perform }
-      browser.checkers.run
+      browser.after_hooks.run
     end
 
     #
@@ -161,7 +161,7 @@ module Watir
       assert_has_input_devices_for :right_click
 
       element_call { driver.action.context_click(@element).perform }
-      browser.checkers.run
+      browser.after_hooks.run
     end
 
     #

--- a/lib/watir-webdriver/elements/form.rb
+++ b/lib/watir-webdriver/elements/form.rb
@@ -10,7 +10,7 @@ module Watir
     def submit
       assert_exists
       element_call { @element.submit }
-      run_checkers
+      browser.checkers.run
     end
 
   end # Form

--- a/lib/watir-webdriver/elements/form.rb
+++ b/lib/watir-webdriver/elements/form.rb
@@ -10,7 +10,7 @@ module Watir
     def submit
       assert_exists
       element_call { @element.submit }
-      browser.checkers.run
+      browser.after_hooks.run
     end
 
   end # Form


### PR DESCRIPTION
Related to #351 

This is a quick and working solution to the problem of sharing checkers between. We can actually implement it way easier by passing `Watir::Browser` instance to `Watir::Alert` constructor and just calling `browser#run_checkers` later.

I kinda like this solution more because it remove checkers responsibility from `Watir::Browser` and make API more OO. Though, this means we have to deprecate current API and update it watir-classic too.

@titusfortner @jarmo @jkotests Please take a look. If you don't like this solution, I can easily revert and forget about it.

Specs are in https://github.com/watir/watirspec/pull/67