### PR TITLE
get browser text like text of any other element

### DIFF
--- a/lib/watir-webdriver/browser.rb
+++ b/lib/watir-webdriver/browser.rb
@@ -170,7 +170,7 @@ module Watir
     #
 
     def text
-      @driver.find_element(:tag_name, "body").text
+      body.text
     end
 
     #


### PR DESCRIPTION
This gives us:
Stale Element Protection. I hit this race condition working with watirspecs on my mac yesterday.
and
Context Protection. Current code will give different responses depending on which frame has recently been pointed to. Browser#text should always return top level, and IFrame#text needs to be used if text from a nested context is desired. 