### PR TITLE
performance improvement for large drop downs

### DIFF
--- a/lib/watir-webdriver/elements/select.rb
+++ b/lib/watir-webdriver/elements/select.rb
@@ -86,17 +86,22 @@ module Watir
 
     def selected?(str_or_rx)
       assert_exists
-      matches = element_call do
-        @element.find_elements(:tag_name, 'option').select do |e|
-          str_or_rx === e.text || str_or_rx === e.attribute(:label)
+
+      match_found = false
+
+      element_call do
+        @element.find_elements(:tag_name, 'option').each do |e|
+          matched = str_or_rx === e.text || str_or_rx === e.attribute(:label)
+          if matched
+            return true if e.selected?
+            match_found = true
+          end
         end
       end
 
-      if matches.empty?
-        raise UnknownObjectException, "Unable to locate option matching #{str_or_rx.inspect}"
-      end
+      raise(UnknownObjectException, "Unable to locate option matching #{str_or_rx.inspect}") unless match_found
 
-      matches.any? { |e| e.selected? }
+      false
     end
 
     #


### PR DESCRIPTION
Our site has some drop downs with a ridiculous number of options in them (over 1,000, don't ask).
The current implementation requires a complete iteration of all options more than once to return a response.
This implementation will return a true response as soon as it finds it, and doesn't add much overhead for iterating through everything to give a false response if it isn't found.