### PR TITLE
rake task to run specs with all browsers

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -121,3 +121,23 @@ end
 load "spec/watirspec/watirspec.rake" if File.exist?("spec/watirspec/watirspec.rake")
 
 task default: [:spec, 'yard:doctest']
+
+
+namespace :spec do
+  require 'selenium-webdriver'
+  desc 'Run specs in all browsers'
+  task all_browsers: [:firefox,
+                      :firefox_nightly,
+                      :chrome,
+                      (:safari if Selenium::WebDriver::Platform.os == :macosx),
+                      (:ie if Selenium::WebDriver::Platform.os == :windows),
+                      (:edge if Selenium::WebDriver::Platform.os == :windows),
+                      :phantomjs].compact
+
+  %i(firefox firefox_nightly chrome safari phantomjs ie edge).each do |browser|
+    task browser do
+      ENV['WATIR_WEBDRIVER_BROWSER'] = browser.to_s
+      Rake::Task['spec'].execute
+    end
+  end
+end


### PR DESCRIPTION
```rake all_browsers``` works to run all applicable tests for all browsers applicable for the operating system. I'm not a rakefile expert, so this probably can be improved.