### PR TITLE
saves 4 wire calls for each navigation

### DIFF
--- a/lib/watir-webdriver/browser.rb
+++ b/lib/watir-webdriver/browser.rb
@@ -77,7 +77,7 @@ module Watir
       @driver.navigate.to uri
       @after_hooks.run
 
-      url
+      uri
     end
 
     #


### PR DESCRIPTION
I was going through the Selenium code with @abaird and noticed that there was a lot more chatter than I expected for the navigation call. I don't think we need to go through the extra overhead of the url method here when we already have the uri that gets returned anyway. 

We just called the /url endpoint, and there is no scenario where we aren't in the top browsing context with an active browser after this. 

The current code Does a /window call then a /windows call then a /frame call then finally another /url call.