### PR TITLE
Element#enabled? should raise when element does not exist

### DIFF
--- a/lib/watir-webdriver/elements/button.rb
+++ b/lib/watir-webdriver/elements/button.rb
@@ -34,16 +34,6 @@ module Watir
       end
     end
 
-    #
-    # Returns true if this element is enabled.
-    #
-    # @return [Boolean]
-    #
-
-    def enabled?
-      !disabled?
-    end
-
     private
 
     def locator_class

--- a/lib/watir-webdriver/elements/element.rb
+++ b/lib/watir-webdriver/elements/element.rb
@@ -410,7 +410,8 @@ module Watir
     #
 
     def enabled?
-      present? && element_call { @element.enabled? }
+      assert_exists
+      element_call { @element.enabled? }
     end
 
     #

--- a/lib/watir-webdriver/elements/input.rb
+++ b/lib/watir-webdriver/elements/input.rb
@@ -3,15 +3,5 @@ module Watir
 
     alias_method :readonly?, :read_only?
 
-    #
-    # Returns true if input is enabled.
-    #
-    # @return [Boolean]
-    #
-
-    def enabled?
-      !disabled?
-    end
-
   end # Input
 end # Watir

--- a/lib/watir-webdriver/elements/select.rb
+++ b/lib/watir-webdriver/elements/select.rb
@@ -3,16 +3,6 @@ module Watir
     include Watir::Exception
 
     #
-    # Returns true if this element is enabled
-    #
-    # @return [Boolean]
-    #
-
-    def enabled?
-      !disabled?
-    end
-
-    #
     # Clears all selected options.
     #
 

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -31,6 +31,24 @@ describe Watir::Element do
 
   end
 
+  describe "#enabled?" do
+    before do
+      browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
+    end
+
+    it "returns true if the element is enabled" do
+      expect(browser.element(name: 'new_user_submit')).to be_enabled
+    end
+
+    it "returns false if the element is disabled" do
+      expect(browser.element(name: 'new_user_submit_disabled')).to_not be_enabled
+    end
+
+    it "raises UnknownObjectException if the element doesn't exist" do
+      expect { browser.element(name: "no_such_name").enabled? }.to raise_error(Watir::Exception::UnknownObjectException)
+    end
+  end
+
   describe "#reset!" do
     it "successfully relocates collection elements after a reset!" do
       browser.goto(WatirSpec.url_for("wait.html"))


### PR DESCRIPTION
Since #363, we have an inconsistent behavior of `#enabled?` across different elements:

1. `Element#enabled?` returns `false` if element is not present.
2. `Button#enabled?` raises `UnknownObjectException` if element is not present (same for other `Element` children implementations).

To me, it makes perfect sense to raise `UnknownObjectException` if element is not present, so I've decided to that it would be better to define the correct behavior on `Element` class and remove all children implementations (though watirspecs are still subject to be removed).

I don't want to push this directly to master without notifying @Rodney-QAGeek and @titusfortner. Since this method is used by `#when_enabled` decorator, it might break somethings for you guys. However, I believe the correct solution is to chain decorators, e.g. `element.when_present.when_enabled.click`.