### PR TITLE
final release as watir-webdriver

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### 0.9.9 (2016-08-01)
+* Final release as watir-webdriver
+
 ### 0.9.3 (2016-07-31)
 
 * Fix warning message for untyped text field (#434)

--- a/lib/watir-webdriver/version.rb
+++ b/lib/watir-webdriver/version.rb
@@ -1,3 +1,3 @@
 module Watir
-  VERSION = '0.9.3'
+  VERSION = '0.9.9'
 end

--- a/watir-webdriver.gemspec
+++ b/watir-webdriver.gemspec
@@ -12,6 +12,12 @@ Gem::Specification.new do |s|
   s.summary     = %q{Watir on WebDriver}
   s.description = %q{WebDriver-backed Watir}
   s.license     = 'MIT'
+  s.post_install_message = <<-POST_INSTALL_MESSAGE
+
+With the release of Watir 6.0, the watir-webdriver gem has changed its name
+to watir. Update your dependencies to use "watir", "~> 6.0"
+
+  POST_INSTALL_MESSAGE
 
   s.rubyforge_project = "watir-webdriver"
 


### PR DESCRIPTION
My Proposed Plan:

1. Merge this
2. Deploy the final watir-webdriver gem on rubygems
3. Rename existing watir github repo to watir_meta & update the Readme about it being deprecated; it does not need a version change or deploy to rubygems, just a commit for the Readme
4. Rename watir-webdriver github repo to watir
5. Merge #395 
6. Add Note to Readme and gemspec of watir-classic that it is no longer actively maintained with a recommendation to `require watir`and deploy to rubygems
7. Steaks for everyone!