### PR TITLE
fix issues with stale elements

### DIFF
--- a/lib/watir-webdriver/elements/element.rb
+++ b/lib/watir-webdriver/elements/element.rb
@@ -597,8 +597,12 @@ module Watir
     def element_call
       yield
     rescue Selenium::WebDriver::Error::StaleElementReferenceError
-      raise unless Watir.always_locate?
-      assert_exists
+      if Watir.always_locate? && !@selector[:element]
+        @element = locate
+      else
+        reset!
+      end
+      assert_element_found
       retry
     end
 

--- a/spec/always_locate_spec.rb
+++ b/spec/always_locate_spec.rb
@@ -35,7 +35,7 @@ describe 'Watir' do
       if Watir.always_locate?
         expect { element.text }.to_not raise_error
       else
-        expect { element.text }.to raise_error
+        expect { element.text }.to raise_error Watir::Exception::UnknownObjectException
       end
     end
   end

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -66,46 +66,15 @@ describe Watir::Element do
       browser.goto WatirSpec.url_for('removed_element.html')
     end
 
-    it "does not propagate StaleElementReferenceErrors" do
-      button = browser.button(id: "remove-button")
-      element = browser.div(id: "text")
-
-      expect(element).to exist
-      button.click
-      expect(element).to_not exist
-    end
-
     it "returns false when an element from a collection becomes stale" do
-      button = browser.button(id: "remove-button")
-      text = browser.divs(id: "text").first
-
-      expect(text).to exist
-      button.click
-      expect(text).to_not exist
-    end
-
-    it "returns false when an element becomes stale" do
-      wd_element = browser.div(id: "text").wd
-
-      # simulate element going stale during lookup
-      allow(browser.driver).to receive(:find_element).with(:id, 'text') { wd_element }
-      browser.refresh
-
-      expect(browser.div(:id, 'text')).to_not exist
-    end
-
-    it "returns appropriate value when an ancestor element becomes stale" do
-      stale_element = browser.div(id: 'top').div(id: 'middle').div(id: 'bottom')
-      expect(stale_element.present?).to be true # look up and store @element for each element in hierarchy
-
-      grandparent = stale_element.instance_variable_get('@parent').instance_variable_get('@parent').instance_variable_get('@element')
-
-      # simulate element going stale during lookup
-      allow(grandparent).to receive('enabled?') { raise Selenium::WebDriver::Error::ObsoleteElementError }
+      watir_element = browser.divs(id: "text").first
+      expect(watir_element).to exist
 
       browser.refresh
-      expect(stale_element.present?).to be Watir.always_locate?
+
+      expect(watir_element).to_not exist
     end
+
   end
 
   describe "#element_call" do
@@ -125,7 +94,7 @@ describe Watir::Element do
       if Watir.always_locate?
         expect { watir_element.text }.to_not raise_error
       else
-        expect { watir_element.text }.to raise_error Selenium::WebDriver::Error::StaleElementReferenceError
+        expect { watir_element.text }.to raise_error Watir::Exception::UnknownObjectException
       end
     end
 


### PR DESCRIPTION
Looking at how these tests were stubbed, I noticed some issues.

1) Result of element going stale between assert exists and action should be the same as other times an element goes stale - (UnknownObjectException not StaleElementReferenceError)

2) Removing an element from the DOM isn't accurately modeling an element going stale, so I don't even know what that is attempting to test.

3) Due to performance issues we no longer check for staleness from the top. We check the bottom element and re-look everything up if that one is stale.

