### PR TITLE
add http to uri if not http

### DIFF
--- a/lib/watir-webdriver/browser.rb
+++ b/lib/watir-webdriver/browser.rb
@@ -72,7 +72,7 @@ module Watir
     #
 
     def goto(uri)
-      uri = "http://#{uri}" unless uri =~ URI.regexp
+      uri = "http://#{uri}" unless uri =~ URI.regexp('http')
 
       @driver.navigate.to uri
       @after_hooks.run


### PR DESCRIPTION
I'm not sure this is the right solution. Is there a case when we would want to use goto for a non-http URI?

Windows uses localhost, which does in fact match `uri =~ URI.regexp` as `URI::Generic`, so 'http' does not get prepended. [This spec](https://github.com/watir/watirspec/blob/master/browser_spec.rb#L160) is passing for non IE support navigating to localhost without http.

The alternative to this PR is to do `not_compliant: :windows` for that spec, and depending on which way we go with this, we'll also want to add a line to the spec like: `expect(uri).to_not match(URI.regexp('http')` to ensure that 'http' actually is getting prepended since that is what it is supposed to be testing.