### PR TITLE
implemented after hooks with selenium event listeners

### DIFF
--- a/lib/watir-webdriver/after_hooks.rb
+++ b/lib/watir-webdriver/after_hooks.rb
@@ -1,3 +1,56 @@
+# TODO - remove this when implemented in Selenium
+module Selenium
+  module WebDriver
+    module Support
+      class EventFiringBridge
+
+        def accept_alert
+          dispatch(:accept_alert, driver) do
+            @delegate.acceptAlert
+          end
+        end
+        alias_method :acceptAlert, :accept_alert
+
+        def dismiss_alert
+          dispatch(:dismiss_alert, driver) do
+            @delegate.dismissAlert
+          end
+        end
+        alias_method :dismissAlert, :dismiss_alert
+
+        def double_click
+          dispatch(:double_click, driver) do
+            @delegate.doubleClick
+          end
+        end
+        alias_method :doubleClick, :double_click
+
+        def context_click
+          dispatch(:context_click, driver) do
+            @delegate.contextClick
+          end
+        end
+        alias_method :right_click, :context_click
+        alias_method :contextClick, :context_click
+
+        def submit_element(id)
+          dispatch(:submit_element, driver) do
+            @delegate.submitElement(id)
+          end
+        end
+        alias_method :submitElement, :submit_element
+
+        def refresh
+          dispatch(:refresh, driver) do
+            @delegate.refresh
+          end
+        end
+
+      end
+    end
+  end
+end
+
 module Watir
 
   #
@@ -10,7 +63,7 @@ module Watir
   #   4. Alert closing.
   #
 
-  class AfterHooks
+  class AfterHooks < Selenium::WebDriver::Support::AbstractEventListener
     include Enumerable
 
     def initialize(browser)
@@ -65,9 +118,16 @@ module Watir
     # Runs after hooks.
     #
 
-    def run
-      if @after_hooks.any? && @browser.window.present?
-        each { |after_hook| after_hook.call(@browser) }
+    %w[navigate_to click context_click accept_alert dismiss_alert double_click right_click
+       submit_element refresh].each do |method|
+      define_method("after_#{method}") do |*args|
+        if @after_hooks.any? && @browser.window.present?
+          each { |after_hook| after_hook.call(@browser) }
+        end
+      end
+      # TODO - remove this when implemented in Selenium
+      define_method("before_#{method}") do |*args|
+        # Do nothing
       end
     end
 

--- a/lib/watir-webdriver/alert.rb
+++ b/lib/watir-webdriver/alert.rb
@@ -35,7 +35,6 @@ module Watir
     def ok
       assert_exists
       @alert.accept
-      @browser.after_hooks.run
     end
 
     #
@@ -50,7 +49,6 @@ module Watir
     def close
       assert_exists
       @alert.dismiss
-      @browser.after_hooks.run
     end
 
     #

--- a/lib/watir-webdriver/browser.rb
+++ b/lib/watir-webdriver/browser.rb
@@ -41,6 +41,11 @@ module Watir
     #
 
     def initialize(browser = :firefox, *args)
+      unless args.find {|a| a[:listener]}
+        @after_hooks = AfterHooks.new(self)
+        args.last.merge!(listener: @after_hooks)
+      end
+
       case browser
       when ::Symbol, String
         @driver = Selenium::WebDriver.for browser.to_sym, *args
@@ -50,7 +55,6 @@ module Watir
         raise ArgumentError, "expected Symbol or Selenium::WebDriver::Driver, got #{browser.class}"
       end
 
-      @after_hooks = AfterHooks.new(self)
       @current_frame  = nil
       @closed = false
     end
@@ -75,7 +79,6 @@ module Watir
       uri = "http://#{uri}" unless uri =~ URI.regexp
 
       @driver.navigate.to uri
-      @after_hooks.run
 
       uri
     end
@@ -200,7 +203,6 @@ module Watir
 
     def refresh
       @driver.navigate.refresh
-      @after_hooks.run
     end
 
     #
@@ -279,42 +281,6 @@ module Watir
 
     def screenshot
       Screenshot.new driver
-    end
-
-    #
-    # @deprecated Use `Watir::AfterHooks#add` instead
-    #
-
-    def add_checker(checker = nil, &block)
-      warn 'Browser#add_checker is deprecated. Use Browser#after_hooks#add instead.'
-      @after_hooks.add(checker, &block)
-    end
-
-    #
-    # @deprecated Use `Watir::AfterHooks#delete` instead
-    #
-
-    def disable_checker(checker)
-      warn 'Browser#disable_checker is deprecated. Use Browser#after_hooks#delete instead.'
-      @after_hooks.delete(checker)
-    end
-
-    #
-    # @deprecated Use `Watir::AfterHooks#run` instead
-    #
-
-    def run_checkers
-      warn 'Browser#run_checkers is deprecated. Use Browser#after_hooks#run instead.'
-      @after_hooks.run
-    end
-
-    #
-    # @deprecated Use `Watir::AfterHooks#without` instead
-    #
-
-    def without_checkers(&block)
-      warn 'Browser#without_checkers is deprecated. Use Browser#after_hooks#without instead.'
-      @after_hooks.without(&block)
     end
 
     #

--- a/lib/watir-webdriver/elements/element.rb
+++ b/lib/watir-webdriver/elements/element.rb
@@ -128,8 +128,6 @@ module Watir
           @element.click
         end
       end
-
-      browser.after_hooks.run
     end
 
     #
@@ -145,7 +143,6 @@ module Watir
       assert_has_input_devices_for :double_click
 
       element_call { driver.action.double_click(@element).perform }
-      browser.after_hooks.run
     end
 
     #
@@ -161,7 +158,6 @@ module Watir
       assert_has_input_devices_for :right_click
 
       element_call { driver.action.context_click(@element).perform }
-      browser.after_hooks.run
     end
 
     #

--- a/lib/watir-webdriver/elements/form.rb
+++ b/lib/watir-webdriver/elements/form.rb
@@ -10,7 +10,6 @@ module Watir
     def submit
       assert_exists
       element_call { @element.submit }
-      browser.after_hooks.run
     end
 
   end # Form


### PR DESCRIPTION
DO NOT MERGE - 
This code monkey patches Selenium for it to work, but I wanted to show off this proof-of-concept for how we can use Selenium's Event Listeners to do our after hooks. 

I think we'll actually want to create some kind of WatirEventListener sub-class to allow more extensible options for adding and removing before & after hooks, along with the current defaults.